### PR TITLE
document how to create slack bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ SLACK_BOT_TOKEN=
 
 # A "User Legacy Token" of your Slack App, used to access the "users.profile.get" API 
 SLACK_USER_TOKEN=
+
+# Bot configuration (optional)
+#
+# DRY_RUN_BOUNTY_APPROVAL=true

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ Right now the bot has two sets of capabilities:
 
 The project board names, column names, welcome message and other values are stored in the `.github/github-bot.yml` file. It can be overriden for each specific repository by adding a file in the same path on the respective repository (see [probot-config](https://github.com/getsentry/probot-config)).
 
+## Development
+
+To get your environment set up go through the following steps:
+
+1. Run `npm install`
+2. Populate `.env`
+
+   ```sh
+   cp .env.example .env
+   # edit .env file to contain proper config
+   ```
+
+After this you can start the bot by running:
+```sh
+npm start
+```
+
 ## Creating the bot GitHub App
 
 This bot is meant to be packaged as a GitHub App. There are two steps to it: creating the app, and installing the app. Creating a GitHub App only needs to be done once and the app can be made public to be reused for any number of repositories and organizations.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ After this you can start the bot by running:
 npm start
 ```
 
+## Creating the Slack Bot Integration
+
+1. Go to https://my.slack.com/services/new/bot
+2. Add a bot integration
+3. Note the bot token starting with `xoxb-` and put it into `.env`
+
 ## Creating the bot GitHub App
 
 This bot is meant to be packaged as a GitHub App. There are two steps to it: creating the app, and installing the app. Creating a GitHub App only needs to be done once and the app can be made public to be reused for any number of repositories and organizations.
@@ -71,6 +77,7 @@ See the official [docs for deployment](https://probot.github.io/docs/deployment/
             - [x] Check the box for **Project for organization projects** events
         - Single File - **Read-only**
             - Path: `.github/github-bot.yml`
+    1. 🔍  Verify that you have **ticked 8 boxes**.
     1. Generate a private key pass and save it.
 1. Installing the bot service:
     1. Deploy the bot to the cloud.


### PR DESCRIPTION
This explicitly documents how to get the required slackbot token. Since Slack apps can also provide bot users there are two ways to do things. This documents that we use the "Custom Integration" way (which is coupled to a workspace) vs the "Slack App" way (which can be added to multiple workspaces).