### PR TITLE
add script to request reviews via comment

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -12,6 +12,11 @@ bounty-project-board:
 welcome-bot:
   message: 'Thanks for making your first PR here!'
 
+github:
+  slack-mapping:
+    # - github: slack
+    martinklepsch: slack
+
 slack:
   notification:
     room: 'status-probot'

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = async (robot) => {
 
   require('./bot_scripts/assign-new-pr-to-review')(robot)
   require('./bot_scripts/assign-approved-pr-to-test')(robot)
+  require('./scripts/assign-pr-via-comment')(robot)
   require('./bot_scripts/assign-to-bounty-awaiting-for-approval')(robot)
   require('./bot_scripts/greet-new-contributor')(robot)
 

--- a/scripts/assign-pr-via-comment.js
+++ b/scripts/assign-pr-via-comment.js
@@ -1,0 +1,82 @@
+// Description:
+//   Script that listens to comments on GitHub pull requests
+//   and requests a review from the mentioned users
+//
+// Dependencies:
+//   github: "^13.1.0"
+//
+// Author:
+//   Martin Klepsch
+
+const defaultConfig = require('../lib/config')
+
+module.exports = (robot) => {
+  // Comments on PRs are treated as issue comments, the payload
+  // contains a "pull_request" field which can be used to
+  // differentiate from other issue_comment events
+  // TODO might be worth supporting edits as well
+  robot.on('issue_comment.created', async context => {
+    // Make sure we don't listen to our own messages
+    if (context.isBot) { return }
+    robot.log.info('Starting AssignPRViaComment bot')
+
+    // A new PR was opened
+    await assignPullRequestViaComment(context, robot)
+  })
+}
+
+async function assignPullRequestViaComment (context, robot) {
+  const payload = context.payload
+  const github = context.github
+  const config = defaultConfig(robot, '.github/github-bot.yml')
+  const ownerName = payload.repository.owner.login
+  const repoName = payload.repository.name
+  const prNumber = payload.issue.number
+
+  if (undefined === payload.issue.pull_request) {
+    robot.log.debug('Not a Pull request comment')
+    return
+  }
+
+  if (!payload.comment.body.startsWith('/review')) {
+    robot.log.debug('Pull request comment does not start with /review')
+    return
+  }
+
+  // TODO probably this should be enhanced so that not all mentions in a comment
+  // are requested as reviewers. Maybe only inspect the line that starts with /review.
+  const pattern = /\B@([a-z0-9]+)/ig
+  const mentions = payload.comment.body.match(pattern).map(m => m.substr(1))
+  robot.log.info(`Reviewers ${mentions} extracted from body ${payload.comment.body}`)
+
+  robot.log(`assignPullRequestToReviewViaComment - Handling Pull Request Comment #${prNumber} on repo ${ownerName}/${repoName}`)
+
+  var allUsersKnown = true
+  mentions.forEach(m => {
+    if (!config['github']['slack-mapping'][m]) {
+      allUsersKnown = false
+    }
+  })
+
+  if (allUsersKnown) {
+    try {
+      if (process.env.DRY_RUN) {
+        robot.log.info('Would have assigned reviewers to', prNumber, [])
+      } else {
+        // Create a review request for the mentioned users
+        let reviewReq = await github.pullRequests.createReviewRequest({
+          owner: ownerName,
+          repo: repoName,
+          number: prNumber,
+          reviewers: mentions,
+          team_reviewers: []
+        })
+        robot.log.debug('Created ReviewRequest', reviewReq)
+      }
+    } catch (err) {
+      robot.log.error(`Couldn't create ReviewRequest for the PR: ${err}`)
+    }
+  } else {
+    robot.log.error('Unknown user mentioned in review request comment', mentions)
+  }
+}


### PR DESCRIPTION
via #4 

First of all my JS is pretty horrible, which I just realized once again while working on this 🙈 

This PR solves the first part of #4 which is allowing users to request reviews using a comment. It currently takes mentions out of any comment starting with `/review` and requests a review from all mentioned users.

If any mentioned user is not in the Slack username mapping configuration the process will fail. 
If any user does not have write access to the repository the process will fail.

Probably worth doing: 

- [ ] Send a comment if the process failed & why
- [ ] Only extract mentions from the line that starts with `/review` this will allow more text/mentions to be part of a comment without implicitly causing everyone to be requested as reviewer.

I did test this using a project I created but since I can't request a review from myself I would have needed to add another person to the project which I might do eventually but haven't gotten around to yet.

In general I found that this project requires a lot of manual setup (Github App/Slack Team/Slack Integration) which is unfortunate and maybe a little bit annoying to new contributors. While it doesn't seem possible to automate those steps I believe it would be appropriate to have very detailed documentation how to set those things up. Whatever can be automated should be automated. (Project board setup etc.) 

**EDIT** I know did some testing with another person and it seems that push access is required to create review requests 🤔 Will need to add that...