### PR TITLE
add bot script to notify PR reviewers via slack; fix #4

### DIFF
--- a/bot_scripts/notify-reviewers-via-slack.js
+++ b/bot_scripts/notify-reviewers-via-slack.js
@@ -1,0 +1,49 @@
+// Description:
+//   Script that listens for new Review Requests and notifies reviewers on Slack
+//
+// Dependencies:
+//   @slack/client: ""
+//
+// Author:
+//   Martin Klepsch (martinklepsch)
+
+const { WebClient } = require('@slack/client')
+const slackWeb = new WebClient(process.env.SLACK_BOT_TOKEN)
+const botName = 'notify-reviwers-via-slack'
+
+module.exports = (robot, getSlackIdFromGitHubId) => {
+  robot.log(`${botName} - Starting...`)
+  registerForNewReviewRequests(robot, getSlackIdFromGitHubId)
+}
+
+function registerForNewReviewRequests (robot, getSlackIdFromGitHubId) {
+  robot.on('pull_request.review_requested', async context => {
+    // Make sure we don't listen to our own messages
+    if (context.isBot) return null
+
+    await notifyReviewers(context, robot, getSlackIdFromGitHubId)
+  })
+}
+
+async function notifyReviewers (context, robot, getSlackIdFromGitHubId) {
+  const { payload } = context
+
+  for (var reviewer of payload.pull_request.requested_reviewers) {
+    const userID = getSlackIdFromGitHubId(reviewer.login)
+
+    if (userID === undefined) {
+      robot.log.error('Could not find Slack ID for GitHub user', reviewer.login)
+    } else {
+      slackWeb.im.open(userID).then((resp) => {
+        const dmChannelID = resp.channel.id
+        const octoboxNote = 'For more powerful management of GitHub notifications also check out https://octobox.io/'
+        const msg = `New Pull Request awaiting review: ${payload.pull_request.html_url}\n${octoboxNote}`
+
+        robot.log.info(`${botName} - Opened DM Channel ${dmChannelID}`)
+        robot.log.info(`Notifying ${userID} about review request in ${payload.pull_request.url}`)
+
+        slackWeb.chat.postMessage(dmChannelID, msg, {unfurl_links: true, as_user: 'probot'})
+      }).catch(error => robot.log.error('Could not open DM channel for review request notification', error))
+    }
+  }
+}

--- a/bot_scripts/notify-reviewers-via-slack.js
+++ b/bot_scripts/notify-reviewers-via-slack.js
@@ -9,7 +9,8 @@
 
 const { WebClient } = require('@slack/client')
 const slackWeb = new WebClient(process.env.SLACK_BOT_TOKEN)
-const botName = 'notify-reviwers-via-slack'
+const botName = 'notify-reviewers-via-slack'
+const botUserName = 'probot'
 
 module.exports = (robot, getSlackIdFromGitHubId) => {
   robot.log(`${botName} - Starting...`)
@@ -28,11 +29,11 @@ function registerForNewReviewRequests (robot, getSlackIdFromGitHubId) {
 async function notifyReviewers (context, robot, getSlackIdFromGitHubId) {
   const { payload } = context
 
-  for (var reviewer of payload.pull_request.requested_reviewers) {
+  for (let reviewer of payload.pull_request.requested_reviewers) {
     const userID = getSlackIdFromGitHubId(reviewer.login)
 
     if (userID === undefined) {
-      robot.log.error('Could not find Slack ID for GitHub user', reviewer.login)
+      robot.log.warn('Could not find Slack ID for GitHub user', reviewer.login)
     } else {
       slackWeb.im.open(userID).then((resp) => {
         const dmChannelID = resp.channel.id
@@ -42,7 +43,7 @@ async function notifyReviewers (context, robot, getSlackIdFromGitHubId) {
         robot.log.info(`${botName} - Opened DM Channel ${dmChannelID}`)
         robot.log.info(`Notifying ${userID} about review request in ${payload.pull_request.url}`)
 
-        slackWeb.chat.postMessage(dmChannelID, msg, {unfurl_links: true, as_user: 'probot'})
+        slackWeb.chat.postMessage(dmChannelID, msg, {unfurl_links: true, as_user: botUserName})
       }).catch(error => robot.log.error('Could not open DM channel for review request notification', error))
     }
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = async (robot) => {
 
   // Add scripts which require using the Slack/GitHub cache after this comment
   require('./bot_scripts/bounty-awaiting-approval-slack-ping')(robot, getSlackMentionFromGitHubId)
+  require('./bot_scripts/notify-reviewers-via-slack')(robot, getSlackIdFromGitHubId)
 
   // For more information on building apps:
   // https://probot.github.io/docs/
@@ -32,4 +33,8 @@ function getSlackMentionFromGitHubId (gitHubId) {
     return null
   }
   return `<@${id}>`
+}
+
+function getSlackIdFromGitHubId (gitHubId) {
+  return SlackGitHubCacheBuilder.getSlackIdFromGitHubId(gitHubId, slackGitHubCache)
 }

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -10,6 +10,8 @@
 module.exports.sendMessage = async (robot, slackClient, room, message) => {
   // Send message to Slack
   if (slackClient != null) {
+    // TODO BOUNTY migrate away from datastore:
+    // https://github.com/slackapi/node-slack-sdk/wiki/DataStore-v3.x-Migration-Guide
     const channel = slackClient.dataStore.getChannelByName(room)
     try {
       if (process.env.DRY_RUN) {


### PR DESCRIPTION
via #4

#### Noteworthy things:

- I didn't use the `probot-slack-status` library because it seemingly didn't expose the WebClient API which I believe is needed to open new IM channels/retrieve DM channel IDs.
- For some reason `unfurl_links` does not seem to have any effect but I only tested with one PR so it might be because the link has already been seen/unfurled in recent history.
- I added a note about [Octobox](https://octobox.io/) which I think is pretty neat for managing notifications in general. 

On a side note: It might be worth copying the code of `probot-status-slack` into this repo instead of maintaining it as a separate dependency. It seems to be a relatively small library with a single 65loc file: https://github.com/PombeirP/probot-slack/blob/master/index.js