### PR TITLE
update names and format of e2e job arguments

### DIFF
--- a/bot_scripts/trigger-automation-test-build.js
+++ b/bot_scripts/trigger-automation-test-build.js
@@ -215,7 +215,7 @@ async function processPullRequest (context, robot, prInfo, fullJobName) {
   }
 
   try {
-    const args = { parameters: { pr_id: prInfo.number, apk: `--apk=${prInfo.number}.apk` } }
+    const args = { parameters: { PR_ID: prInfo.number, APK_NAME: `${prInfo.number}.apk` } }
 
     if (process.env.DRY_RUN) {
       robot.log(`${botName} - Would start ${fullJobName} job in Jenkins`, prInfo, args)


### PR DESCRIPTION
Update for arguments of a newly configured e2e CI job:
https://ci.status.im/job/end-to-end-tests/job/status-app-prs/
https://github.com/status-im/status-react/pull/9171 introduces the `ci/tests/Jenkinsfile.e2e-prs` and changes the arguments as well as updates the `.github/github-bot.yml`.