### PR TITLE
drop APK_NAME param for e2e jobs

### DIFF
--- a/bot_scripts/trigger-automation-test-build.js
+++ b/bot_scripts/trigger-automation-test-build.js
@@ -215,7 +215,7 @@ async function processPullRequest (context, robot, prInfo, fullJobName) {
   }
 
   try {
-    const args = { parameters: { PR_ID: prInfo.number, APK_NAME: `${prInfo.number}.apk` } }
+    const args = { parameters: { PR_ID: prInfo.number } }
 
     if (process.env.DRY_RUN) {
       robot.log(`${botName} - Would start ${fullJobName} job in Jenkins`, prInfo, args)


### PR DESCRIPTION
It's no longer necessary as PR ID by itself allows for copying of the `x86` APK from the correct Jenkins job artifacts directly.

Related to:
* https://github.com/status-im/status-mobile/pull/14993

I will remove it from the `Jenkinsfile` in a separate PR once this is merged and deployed.